### PR TITLE
Rota user-logged alterada para incluir json web token

### DIFF
--- a/src/modules/auth/auth.controller.ts
+++ b/src/modules/auth/auth.controller.ts
@@ -23,7 +23,7 @@ export class AuthController {
   }
 
   @Get('/user-logged')
-  @UseGuards(AuthGuard())
+  @UseGuards(AuthGuard('jwt'))
   @UserLoggedSwagger()
   @ApiBearerAuth()
   async userLogged(@LoggedUser() user: UsersEntity) {


### PR DESCRIPTION
Durante a chamada dessa rota há a autenticação via authguard que emprega o token gerado durante o login do usuário. Essa autenticação é feita com base na informação do método de autenticação, em específico jwt (json web token). No código, no entanto, essa informação não estava sendo dada à função, que estava sendo chamada sem parâmetros o que fazia a rota quebrar e não funcionar.