### PR TITLE
feat Criação do Serviço de Candidatura

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -16,6 +16,7 @@ import { UserModule } from './modules/user/user.module';
 import { ApplicationsModule } from './modules/applications/applications.module';
 import { typeormConfig } from './database/data-source';import { PassportModule } from '@nestjs/passport';
 import { AlertsService } from './alerts/alerts.service';
+import { CandidacyService } from './candidacy/candidacy.service';
 
 @Module({
   imports: [
@@ -40,6 +41,6 @@ import { AlertsService } from './alerts/alerts.service';
     ApplicationsModule,
   ],
   controllers: [AppController],
-  providers: [AppService, AlertsService],
+  providers: [AppService, AlertsService, CandidacyService],
 })
 export class AppModule {}

--- a/src/candidacy/candidacy.service.spec.ts
+++ b/src/candidacy/candidacy.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { CandidacyService } from './candidacy.service';
+
+describe('CandidacyService', () => {
+  let service: CandidacyService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [CandidacyService],
+    }).compile();
+
+    service = module.get<CandidacyService>(CandidacyService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/candidacy/candidacy.service.ts
+++ b/src/candidacy/candidacy.service.ts
@@ -1,0 +1,29 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { CandidacyRepository } from 'src/modules/candidacy/repository/candidacy.repository';
+import { CreateCandidacyDto } from 'src/candidacy/dto/create-candidacy.dto';
+import { CandidacyEntity } from '../database/entities/candidacy.entity';
+
+@Injectable()
+export class CandidacyService {
+  constructor(
+    @InjectRepository(CandidacyRepository)
+    private readonly candidacyRepository: CandidacyRepository
+  ) {}
+
+  async create(createCandidacyDto: CreateCandidacyDto): Promise<CandidacyEntity> {
+    const candidacy = new CandidacyEntity();
+    candidacy.userId = createCandidacyDto.userId;
+    candidacy.jobId = createCandidacyDto.jobId;
+    candidacy.status = 'Em andamento';
+    return this.candidacyRepository.createCandidacy(candidacy);
+  }
+
+  async getCandidacyByUserId(userId: string): Promise<CandidacyEntity[]> {
+    return this.candidacyRepository.findAllByUserId(userId);
+  }
+
+  async closeCandidacy(id: string, status: 'Encerrada' | 'Sem interesse'): Promise<CandidacyEntity> {
+    return this.candidacyRepository.updateStatus(id, status);
+  }
+}

--- a/src/candidacy/dto/create-candidacy.dto.ts
+++ b/src/candidacy/dto/create-candidacy.dto.ts
@@ -1,0 +1,11 @@
+import { IsUUID, IsNotEmpty } from 'class-validator';
+
+export class CreateCandidacyDto {
+  @IsUUID()
+  @IsNotEmpty()
+  userId: string;
+
+  @IsUUID()
+  @IsNotEmpty()
+  jobId: string;
+}

--- a/src/database/entities/candidacy.entity.ts
+++ b/src/database/entities/candidacy.entity.ts
@@ -1,0 +1,39 @@
+import {
+  Column,
+  Entity,
+  PrimaryGeneratedColumn,
+  ManyToOne,
+  JoinColumn,
+} from 'typeorm';
+import { UsersEntity } from './users.entity'; 
+import { JobsEntity } from './jobs.entity'; 
+
+@Entity('tb_candidacies') 
+export class CandidacyEntity {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column('uuid')
+  jobId: string;
+
+  @Column('uuid')
+  userId: string; 
+
+  @Column({ type: 'enum', enum: ['em andamento', 'encerrada', 'sem interesse'] })
+  status: string;
+
+  @Column({ type: 'timestamp', default: () => 'CURRENT_TIMESTAMP' })
+  dataCandidatura: Date;
+
+  @Column({ type: 'timestamp', nullable: true })
+  dataEncerramento: Date;
+
+  @ManyToOne(() => UsersEntity)
+  @JoinColumn({ name: 'userId' })
+  user: UsersEntity; 
+
+  @ManyToOne(() => JobsEntity)
+  @JoinColumn({ name: 'jobId' })
+  job: JobsEntity;
+}
+

--- a/src/database/entities/candidacy.entity.ts
+++ b/src/database/entities/candidacy.entity.ts
@@ -27,7 +27,7 @@ export class CandidacyEntity {
   dateCandidacy: Date;
 
   @Column({ type: 'timestamp', nullable: true })
-  dateaClosing: Date;
+  dateClosing: Date;
 
   @ManyToOne(() => UsersEntity)
   @JoinColumn({ name: 'userId' })

--- a/src/database/entities/candidacy.entity.ts
+++ b/src/database/entities/candidacy.entity.ts
@@ -7,6 +7,7 @@ import {
 } from 'typeorm';
 import { UsersEntity } from './users.entity'; 
 import { JobsEntity } from './jobs.entity'; 
+import { CandidacyStatus } from './candidancy-status.enum';
 
 @Entity('tb_candidacies') 
 export class CandidacyEntity {
@@ -19,14 +20,14 @@ export class CandidacyEntity {
   @Column('uuid')
   userId: string; 
 
-  @Column({ type: 'enum', enum: ['em andamento', 'encerrada', 'sem interesse'] })
-  status: string;
+  @Column({ type: 'enum', enum: CandidacyStatus })
+  status: CandidacyStatus;
 
   @Column({ type: 'timestamp', default: () => 'CURRENT_TIMESTAMP' })
-  dataCandidatura: Date;
+  dateCandidacy: Date;
 
   @Column({ type: 'timestamp', nullable: true })
-  dataEncerramento: Date;
+  dateaClosing: Date;
 
   @ManyToOne(() => UsersEntity)
   @JoinColumn({ name: 'userId' })

--- a/src/database/entities/candidacy.entity.ts
+++ b/src/database/entities/candidacy.entity.ts
@@ -4,37 +4,40 @@ import {
   PrimaryGeneratedColumn,
   ManyToOne,
   JoinColumn,
-} from 'typeorm';
-import { UsersEntity } from './users.entity'; 
-import { JobsEntity } from './jobs.entity'; 
-import { CandidacyStatus } from './candidancy-status.enum';
-
-@Entity('tb_candidacies') 
-export class CandidacyEntity {
+  } from 'typeorm';
+  import { UsersEntity } from './users.entity';
+  import { JobsEntity } from './jobs.entity';
+  import { CandidacyStatus } from './candidancy-status.enum';
+  
+  @Entity('tb_candidacies', { indexes: [{ columns: ['userId'] }, { columns: ['jobId'] }] })
+  export class CandidacyEntity {
   @PrimaryGeneratedColumn('uuid')
   id: string;
-
+  
   @Column('uuid')
   jobId: string;
-
+  
   @Column('uuid')
-  userId: string; 
-
+  userId: string;
+  
   @Column({ type: 'enum', enum: CandidacyStatus })
   status: CandidacyStatus;
-
+  
   @Column({ type: 'timestamp', default: () => 'CURRENT_TIMESTAMP' })
   dateCandidacy: Date;
-
-  @Column({ type: 'timestamp', nullable: true })
+  
+  @Column({
+  type: 'timestamp',
+  nullable: true,
+  onUpdate: () => 'CURRENT_TIMESTAMP'
+  })
   dateClosing: Date;
-
+  
   @ManyToOne(() => UsersEntity)
   @JoinColumn({ name: 'userId' })
-  user: UsersEntity; 
-
+  user: UsersEntity;
+  
   @ManyToOne(() => JobsEntity)
   @JoinColumn({ name: 'jobId' })
   job: JobsEntity;
-}
-
+  }

--- a/src/database/entities/candidancy-status.enum.ts
+++ b/src/database/entities/candidancy-status.enum.ts
@@ -1,0 +1,5 @@
+export enum CandidacyStatus {
+    InProgress = 'em andamento',
+    Closed = 'encerrada',
+    NoInterest = 'sem interesse',
+}

--- a/src/database/entities/users.entity.ts
+++ b/src/database/entities/users.entity.ts
@@ -11,6 +11,7 @@ import {
 import { ApplicationEntity } from './applications.entity';
 import { CurriculumEntity } from './curriculum.entity';
 import { PersonalDataEntity } from './personal-data.entity';
+import { CandidacyEntity } from './candidacy.entity';
 
 enum RolesEnum {
   ADMIN = 'ADMIN',
@@ -71,6 +72,9 @@ export class UsersEntity {
 
   @OneToMany(() => ApplicationEntity, (application) => application.user)
   applications: ApplicationEntity[];
+
+  @OneToMany(() => CandidacyEntity, (candidacy) => candidacy.user)
+  candidacies: CandidacyEntity[];
 
   @CreateDateColumn()
   created_at: Date;

--- a/src/modules/candidacy/repository/candidacy.repository.ts
+++ b/src/modules/candidacy/repository/candidacy.repository.ts
@@ -1,0 +1,40 @@
+import { Injectable } from '@nestjs/common';
+import { Repository } from 'typeorm';
+import { CandidacyEntity } from '../../../database/entities/candidacy.entity';
+import { InjectRepository } from '@nestjs/typeorm';
+
+@Injectable()
+export class CandidacyRepository {
+  constructor(
+    @InjectRepository(CandidacyEntity)
+    private candidacyRepository: Repository<CandidacyEntity>,
+  ) {}
+
+  async createCandidacy(candidacy: CandidacyEntity): Promise<CandidacyEntity> {
+    return this.candidacyRepository.save(candidacy);
+  }
+
+  async findAllByUserId(userId: string): Promise<CandidacyEntity[]> {
+    return this.candidacyRepository.find({ where: { user: { id: userId } } });
+  }
+
+  async updateStatus(id: string, status: string): Promise<CandidacyEntity | undefined> {
+    try {
+      const candidacies = await this.candidacyRepository.find({ where: { id } });
+
+      if (candidacies.length === 0) {
+        return undefined;
+      }
+        const candidacyToUpdate = candidacies[0];
+      candidacyToUpdate.status = status;
+
+      await this.candidacyRepository.save(candidacyToUpdate);
+
+      return candidacyToUpdate;
+    } catch (error) {
+
+        return undefined;
+    }
+  }
+
+}


### PR DESCRIPTION
Criação do Serviço de Candidatura:
    
Serviço CandidaturaService:
     ◦ create(createCandidaturaDto: CreateCandidaturaDto): Criar uma nova candidatura.
     ◦ getCandidaturasByUsuarioId(usuarioId: UUID): Retornar todas as candidaturas em andamento de um usuário.
     ◦ encerrarCandidatura(id: UUID): Atualizar o status da candidatura para "Encerrada" ou "Sem interesse".

Lógica de Status:
     ◦ Gerenciar os status de cada candidatura: "Em andamento", "Encerrada", e "Sem interesse".