### PR TITLE
feat(config): atualizar variáveis para habilitar SSL e Swagger

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,9 @@
 NODE_ENV="development"
 PORT= # Porta onde o projeto vai rodar na sua máquina
 
+# Swagger
+SWAGGER_ENABLE="true" # Habilitar documentação Swagger
+
 # JWT
 SECRET_KEY="" # Uma string qualquer, chave para gerar o JWT
 
@@ -11,8 +14,9 @@ TYPEORM_PORT=5432                   # A porta geralmente é 5432, se no seu caso
 TYPEORM_USERNAME="docker"           # Usuário do servidor Postgres via docker compose
 TYPEORM_PASSWORD="ignite"           # Senha do servidor Postgres via docker compose
 TYPEORM_DATABASE="linkedin_backend" # Banco de dados a ser conectado via docker compose
+TYPEORM_ENABLE_SSL="false"          # Habilitar SSL para conexão do banco de dados
 
-CA_CERT="" # Apenas para o db em produção
+CA_CERT="" # Certificado para conexão SSL
 
 # AWS S3
 AWS_ACCESS_KEY_ID=""

--- a/src/database/data-source.ts
+++ b/src/database/data-source.ts
@@ -9,6 +9,7 @@ const {
   TYPEORM_PASSWORD,
   TYPEORM_USERNAME,
   TYPEORM_DATABASE,
+  TYPEORM_ENABLE_SSL,
   CA_CERT,
 } = process.env;
 
@@ -25,7 +26,7 @@ export const typeormConfig: DataSourceOptions = {
     'dist/database/migrations/seeds/*.js',
   ],
   ssl:
-    NODE_ENV == 'production'
+    TYPEORM_ENABLE_SSL == 'true'
       ? {
           ca: CA_CERT,
           rejectUnauthorized: false,

--- a/src/main.ts
+++ b/src/main.ts
@@ -30,7 +30,7 @@ async function bootstrap() {
 
   const document = SwaggerModule.createDocument(app, config);
 
-  if (process.env.ENABLE_SWAGGER == 'true') {
+  if (process.env.SWAGGER_ENABLE == 'true') {
     SwaggerModule.setup('api', app, document);
     console.info(
       `Documentation running on http://localhost:${process.env.PORT || 3000}/api 🚀🚀`,

--- a/src/main.ts
+++ b/src/main.ts
@@ -30,7 +30,7 @@ async function bootstrap() {
 
   const document = SwaggerModule.createDocument(app, config);
 
-  if (process.env.NODE_ENV == 'development') {
+  if (process.env.ENABLE_SWAGGER == 'true') {
     SwaggerModule.setup('api', app, document);
     console.info(
       `Documentation running on http://localhost:${process.env.PORT || 3000}/api 🚀🚀`,


### PR DESCRIPTION
## Propósito
Desacoplar Configurações de Ambiente para Maior Flexibilidade e Configurabilidade

## Mudanças
- Removida dependência rígida de `NODE_ENV` para configurações de SSL e Swagger
- Introduzida configuração independente de ambiente via variáveis de ambiente específicas
- Habilitação de SSL e Swagger agora controlada por flags dedicadas

## Motivação
Melhorar a arquitetura de configuração através de:
- Desacoplamento de configurações de ambiente
- Maior granularidade no controle de recursos
- Flexibilidade para habilitar/desabilitar recursos independentemente do ambiente

## Detalhes Técnicos
- Substituição de verificações condicionais baseadas em `NODE_ENV`
- Uso de variáveis de ambiente `TYPEORM_ENABLE_SSL` e `SWAGGER_ENABLE`
- Configurações podem ser definidas independentemente do ambiente de execução

## Benefícios
- Configuração mais dinâmica e adaptável
- Redução de acoplamento entre ambiente e configuração
- Facilita testes e configurações personalizadas

## Tipo de Mudança
- [x] Refatoração arquitetural
- [x] Melhoria de configurabilidade
- [x] Desacoplamento de dependências

## Testes
- Verificada independência de configurações
- Testados diferentes cenários de habilitação
- Confirmado comportamento consistente entre ambientes

## Impacto Potencial
- Arquitetura de configuração mais limpa
- Maior flexibilidade de implantação
- Sem alterações que quebrem o código existente

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Novos Recursos**
  - Ativação da documentação Swagger agora pode ser configurada via variável de ambiente.
  - Nova opção permite definir o uso de SSL nas conexões com o banco de dados.
- **Aprimoramentos de Configuração**
  - Comentários atualizados para esclarecer o uso do certificado SSL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->